### PR TITLE
Fixes to Czech translation

### DIFF
--- a/i18n/cs/nova_music.ftl
+++ b/i18n/cs/nova_music.ftl
@@ -16,7 +16,7 @@ Loading = Načítání...
 
 # Common Terms
 album = Album
-title = Titulek
+title = Název
 artist = Umělec
 pageresults = Výsledky {$number}
 singles = Singly
@@ -31,7 +31,7 @@ firsttimeprimary = Skenovat složku a pokračovat
 
 # Playlist Creation Dialog
 DialogPlaylistTitle = Vytvořit nový playlist
-DialogPlaylistChosenName = Titulek playlistu:
+DialogPlaylistChosenName = Název playlistu:
 DialogPlaylistPrimary = Vytvořit
 # Playlist Deletion Dialog
 DialogPlaylistDelete = Smazat playlist?

--- a/resources/dev.lunarsrl.NovaMusic.metainfo.xml
+++ b/resources/dev.lunarsrl.NovaMusic.metainfo.xml
@@ -35,10 +35,7 @@
             artists. Create m3u8 playlists easily from within the application, choose a name and icon and see it
             displayed on the playlists page for easy access to your favorite songs.
         </p>
-    </description>
-
-    <description xml:lang="cs">
-        <p>
+        <p xml:lang="cs">
             Hudební přehrávač napsaný v toolkitu libcosmic. Prohledává vybraný adresář s audio soubory, načítá metadata a 
             zobrazuje je i organizuje na několika stránkách. Hudbu si můžete prohlížet podle jednotlivých skladeb, alb nebo
             umělců. Přímo v aplikaci lze snadno vytvářet playlisty ve formátu m3u8 – zvolíte název, ikonu a playlist se 


### PR DESCRIPTION
Hey there again 🙂

From another project, I found out that the localized description in metainfo should be under one <description> element, so I'm fixing that + a minor update to Czech i18n.